### PR TITLE
Fix hashtag bugs

### DIFF
--- a/little_boxes/content_helper.py
+++ b/little_boxes/content_helper.py
@@ -26,8 +26,9 @@ def hashtagify(content: str) -> Tuple[str, List[Dict[str, str]]]:
     base_url = get_backend().base_url()
     tags = []
     hashtags = re.findall(HASHTAG_REGEX, content)
+    hashtags = list(set(hashtags))  # unique tags
     hashtags.sort()
-    hashtags.reverse()  # replace longest tags first
+    hashtags.reverse()  # replace longest tag first
     for hashtag in hashtags:
         tag = hashtag[1:]
         link = f'<a href="{base_url}/tags/{tag}" class="mention hashtag" rel="tag">#<span>{tag}</span></a>'

--- a/little_boxes/content_helper.py
+++ b/little_boxes/content_helper.py
@@ -1,9 +1,10 @@
-import re
 from typing import Dict
 from typing import List
 from typing import Tuple
 
 from markdown import markdown
+
+import regex as re
 
 from .activitypub import get_backend
 from .webfinger import get_actor_url
@@ -24,7 +25,10 @@ MENTION_REGEX = re.compile(r"@[\d\w_.+-]+@[\d\w-]+\.[\d\w\-.]+")
 def hashtagify(content: str) -> Tuple[str, List[Dict[str, str]]]:
     base_url = get_backend().base_url()
     tags = []
-    for hashtag in re.findall(HASHTAG_REGEX, content):
+    hashtags = re.findall(HASHTAG_REGEX, content)
+    hashtags.sort()
+    hashtags.reverse()  # replace longest tags first
+    for hashtag in hashtags:
         tag = hashtag[1:]
         link = f'<a href="{base_url}/tags/{tag}" class="mention hashtag" rel="tag">#<span>{tag}</span></a>'
         tags.append(dict(href=f"{base_url}/tags/{tag}", name=hashtag, type="Hashtag"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ markdown
 pyld
 pycryptodome
 html2text
+regex

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
+from distutils.core import setup
 import io
 import os
-from distutils.core import setup
 
 from setuptools import find_packages
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -29,6 +30,7 @@ REQUIRED = [
     "pycryptodome",
     "html2text",
     "mdx_linkify",
+    "regex",
 ]
 
 DEPENDENCY_LINKS = []


### PR DESCRIPTION
This PR will fix the following bugs

1. Tag with unicode vowels. Python re does not include unicode vowels in "\w", regex package already fix this issue.
2. Longer tag that come later is shadowed by shorter tag e.g. if I have #Redis and #RedisLab in the same note, the link for Redis tag will also replace Redis in RedisLab.
3. hashtagify() is trying to replace the same tag multiple times if there are many same tag in a note.