### PR TITLE
Add Audio (and Document) Activity Type

### DIFF
--- a/little_boxes/activitypub.py
+++ b/little_boxes/activitypub.py
@@ -126,6 +126,7 @@ CREATE_TYPES = [
     ActivityType.VIDEO,
     ActivityType.AUDIO,
     ActivityType.QUESTION,
+    ActivityType.DOCUMENT
 ]
 
 COLLECTION_TYPES = [ActivityType.COLLECTION, ActivityType.ORDERED_COLLECTION]

--- a/little_boxes/activitypub.py
+++ b/little_boxes/activitypub.py
@@ -86,6 +86,7 @@ class ActivityType(Enum):
     ARTICLE = "Article"
     VIDEO = "Video"
     AUDIO = "Audio"
+    DOCUMENT = "Document"
 
     ACCEPT = "Accept"
     REJECT = "Reject"
@@ -908,7 +909,13 @@ class Video(Note):
     OBJECT_REQURIED = False
 
 
-class Audio(Note):
+class Document(BaseActivity):
+    ACTIVITY_TYPE = ActivityType.DOCUMENT
+    ACTOR_REQUIRED = True
+    OBJECT_REQUIRED = False
+
+
+class Audio(Document):
     ACTIVITY_TYPE = ActivityType.AUDIO
     ACTOR_REQUIRED = True
     OBJECT_REQUIRED = False

--- a/little_boxes/activitypub.py
+++ b/little_boxes/activitypub.py
@@ -85,6 +85,7 @@ class ActivityType(Enum):
     NOTE = "Note"
     ARTICLE = "Article"
     VIDEO = "Video"
+    AUDIO = "Audio"
 
     ACCEPT = "Accept"
     REJECT = "Reject"
@@ -122,6 +123,7 @@ CREATE_TYPES = [
     ActivityType.NOTE,
     ActivityType.ARTICLE,
     ActivityType.VIDEO,
+    ActivityType.AUDIO,
     ActivityType.QUESTION,
 ]
 
@@ -904,6 +906,12 @@ class Video(Note):
     ACTIVITY_TYPE = ActivityType.VIDEO
     ACTOR_REQUIRED = True
     OBJECT_REQURIED = False
+
+
+class Audio(Note):
+    ACTIVITY_TYPE = ActivityType.AUDIO
+    ACTOR_REQUIRED = True
+    OBJECT_REQUIRED = False
 
 
 def fetch_remote_activity(

--- a/little_boxes/activitypub.py
+++ b/little_boxes/activitypub.py
@@ -910,13 +910,13 @@ class Video(Note):
     OBJECT_REQURIED = False
 
 
-class Document(BaseActivity):
+class Document(Note):
     ACTIVITY_TYPE = ActivityType.DOCUMENT
     ACTOR_REQUIRED = True
     OBJECT_REQUIRED = False
 
 
-class Audio(Document):
+class Audio(Note):
     ACTIVITY_TYPE = ActivityType.AUDIO
     ACTOR_REQUIRED = True
     OBJECT_REQUIRED = False


### PR DESCRIPTION
I wanted to federate audio activities and added it.

At first I wanted Audio to extend Document as per AP spec, but since everything seems to extend Note, I've splitted Audio and Document which now both use Note.

I can drop Document if you want.